### PR TITLE
Fix ownership/permissions of parent directories of user-specific paths

### DIFF
--- a/docs/src/examples.md
+++ b/docs/src/examples.md
@@ -169,13 +169,9 @@ mount created by system to the persistent volume.
 
   # Create some directories with custom permissions.
   #
-  # In this configuration the path `/home/butz/.local` is not an immediate parent
-  # of any persisted file, so it would be created with the systemd-tmpfiles default
-  # ownership `root:root` and mode `0755`. This would mean that the user `butz`
-  # could not create other files or directories inside `/home/butz/.local`.
-  #
-  # Therefore systemd-tmpfiles is used to prepare such directories with
-  # appropriate permissions.
+  # This is not necessary for user-specific files, as intermediate components
+  # of such paths (up to and including the home directory) are created with
+  # the user's ownership and mode `0755`.
   #
   # Note that immediate parent directories of persisted files can also be
   # configured with ownership and permissions from the `parent` settings if

--- a/docs/src/impermanence-migration.md
+++ b/docs/src/impermanence-migration.md
@@ -53,7 +53,9 @@ to be preserved, and optionally their immediate parent directories (via `configu
 the `parent` options).
 
 All missing components of a preserved path that do not already exist, are created by
-systemd-tmpfiles with default ownership `root:root` and mode `0755`.
+systemd-tmpfiles with default ownership `root:root` and mode `0755`, except for user-specific
+paths, where intermediate components (up to and including the home directory) are created
+with the user's ownership and mode `0755`.
 
 Should such directories require different ownership or mode, the intended way to provision them
 is directly via systemd-tmpfiles.

--- a/module.nix
+++ b/module.nix
@@ -7,6 +7,7 @@ let
     mkRegularMountUnits
     mkInitrdMountUnits
     mkRegularTmpfilesRules
+    mkRegularTmpfilesRulesExtra
     mkInitrdTmpfilesRules
     ;
 in
@@ -43,6 +44,10 @@ in
       };
       tmpfiles.settings.preservation = lib.mkMerge (
         lib.flatten (lib.mapAttrsToList mkRegularTmpfilesRules cfg.preserveAt)
+      );
+      # use a separate, lower priority file for extra tmpfiles rules
+      tmpfiles.settings.preservationExtra = lib.mkMerge (
+        lib.flatten (lib.mapAttrsToList mkRegularTmpfilesRulesExtra cfg.preserveAt)
       );
       mounts = lib.flatten (lib.mapAttrsToList mkRegularMountUnits cfg.preserveAt);
     };

--- a/options.nix
+++ b/options.nix
@@ -72,6 +72,8 @@ let
 
             By default, missing parent directories are always created with ownership
             `root:root` and mode `0755`, as described in {manpage}`tmpfiles.d(5)`.
+            However, if the parent directories belong to a user-specific directory,
+            they are created with the user's ownership and mode `0755`.
 
             Ownership and mode may be configured through the options
             {option}`parent.user`,
@@ -210,6 +212,8 @@ let
 
             By default, missing parent directories are always created with ownership
             `root:root` and mode `0755`, as described in {manpage}`tmpfiles.d(5)`.
+            However, if the parent directories belong to a user-specific file,
+            they are created with the user's ownership and mode `0755`.
 
             Ownership and mode may be configured through the options
             {option}`parent.user`,
@@ -309,6 +313,24 @@ let
           description = ''
             Specify the path to the user's home directory.
           '';
+        };
+        _homeMode = lib.mkOption {
+          internal = true;
+          readOnly = true;
+          type = lib.types.str;
+          default = config.users.users.${name}.homeMode;
+        };
+        _group = lib.mkOption {
+          internal = true;
+          readOnly = true;
+          type = lib.types.str;
+          default = config.users.users.${name}.group;
+        };
+        _dirMode = lib.mkOption {
+          internal = true;
+          readOnly = true;
+          type = lib.types.str;
+          default = "0755";
         };
         directories = lib.mkOption {
           type =

--- a/tests/basic.nix
+++ b/tests/basic.nix
@@ -182,6 +182,14 @@ in
         for file in all_files:
           check_file(file)
 
+      with subtest("Home directory permissions and ownership"):
+        actual = machine.succeed("stat -c '0%a %U %G' {/state,}${butzHome} | tee /dev/stderr").strip()
+        expected = "0700 butz users\n0700 butz users"
+        assert actual == expected,f"unexpected home directory attributes\nexpected: {expected}\nactual: {actual}"
+        actual = machine.succeed("stat -c '0%a %U %G' {/state,}${butzHome}/.config | tee /dev/stderr").strip()
+        expected = "0755 butz users\n0755 butz users"
+        assert actual == expected,f"unexpected home directory attributes\nexpected: {expected}\nactual: {actual}"
+
       with subtest("Files preserved across reboots"):
         # write something in one of the preserved files
         teststring = "foobarbaz"


### PR DESCRIPTION
This is done by generating extra tmpfiles.d rules for intermediate components of user-specific paths up to and including the home directory.